### PR TITLE
adding check for empty stack before pop

### DIFF
--- a/boilerpy3/parser.py
+++ b/boilerpy3/parser.py
@@ -492,7 +492,8 @@ class BoilerpipeBaseParser:
         self.last_event = self.EVENT_END_TAG
         self.last_end_tag = name
         try:
-            self.label_stacks.pop()
+            if( len(self.label_stacks) != 0 ):
+                self.label_stacks.pop()
         except IndexError:
             if self.raise_on_failure:
                 raise


### PR DESCRIPTION
Hello @jmriebold,

Kindly consider this minor patch:
```
if( len(self.label_stacks) != 0 ):
    self.label_stacks.pop()
```
Which causes this error:
```
Traceback (most recent call last):
  File "/Users/.../venv3/lib/python3.6/site-packages/boilerpy3/extractors.py", line 96, in parse_doc
    bp_parser.feed(input_str)
  File "/Users/.../venv3/lib/python3.6/site-packages/boilerpy3/parser.py", line 657, in feed
    HTMLParser.feed(self, data)
  File "/usr/local/Cellar/python3/3.6.0_1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/html/parser.py", line 111, in feed
    self.goahead(0)
  File "/usr/local/Cellar/python3/3.6.0_1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/html/parser.py", line 173, in goahead
    k = self.parse_endtag(i)
  File "/usr/local/Cellar/python3/3.6.0_1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/html/parser.py", line 421, in parse_endtag
    self.handle_endtag(elem.lower())
  File "/Users/.../venv3/lib/python3.6/site-packages/boilerpy3/parser.py", line 664, in handle_endtag
    self.end_element(tag)
  File "/Users/.../venv3/lib/python3.6/site-packages/boilerpy3/parser.py", line 495, in end_element
    self.label_stacks.pop()
IndexError: pop from empty list

```

Respectfully,

@acnwala